### PR TITLE
fix(TrackInfo): Applying current track to all presets

### DIFF
--- a/liblpe/data/LivePresetsModel.cpp
+++ b/liblpe/data/LivePresetsModel.cpp
@@ -251,13 +251,28 @@ int LivePresetsModel::getRecallIdForPreset(LivePreset* preset, int id) {
  */
 void LivePresetsModel::onApplySelectedTrackConfigsToAllPresets(const std::vector<MediaTrack*>& tracks) {
     for (auto* preset : mPresets) {
-        for (auto* mTrack : preset->mTracks) {
-            for (auto* track : tracks) {
-                if (GuidsEqual(*GetTrackGUID(track), mTrack->mGuid)) {
-                    mTrack->saveCurrentState(true);
+        for (auto* updatingTrack : tracks) {
+            auto guid = *GetTrackGUID(updatingTrack);
+
+            TrackInfo* updatingTrackInfo = nullptr;
+            for (auto* mTrackInfo : preset->mTracks) {
+                if (GuidsEqual(guid, mTrackInfo->mGuid)) {
+                    updatingTrackInfo = mTrackInfo;
                     break;
                 }
             }
+
+            if (updatingTrackInfo == nullptr) {
+                // no existing TrackInfo on preset was found, create a new one
+                updatingTrackInfo = new TrackInfo(nullptr, updatingTrack);
+                preset->mTracks.push_back(updatingTrackInfo);
+                updatingTrackInfo->saveCurrentState(false);
+            } else {
+                // update existing TrackInfo
+                updatingTrackInfo->saveCurrentState(true);
+            }
+
+            preset->mDate = time(nullptr);
         }
     }
 }

--- a/liblpe/data/models/TrackInfo.cpp
+++ b/liblpe/data/models/TrackInfo.cpp
@@ -255,4 +255,5 @@ bool TrackInfo::applyFilterPreset(FilterPreset *preset) {
         }
         return true;
     }
-    return false;}
+    return false;
+}


### PR DESCRIPTION
fix(TrackInfo): Applying current track to all presets now also works for presets that have not saved any data about that track already.