### PR TITLE
fix(data): Now only saving data in the projects .rpp file, when there…

### DIFF
--- a/liblpe/LivePresetsExtension.cpp
+++ b/liblpe/LivePresetsExtension.cpp
@@ -414,7 +414,7 @@ void LPE::saveState(ProjectStateContext* ctx, bool) {
 
     // only save data when there are presets
     if (mModels[proj].mPresets.empty())
-        return
+        return;
 
     WDL_FastString chunk;
     mModels[proj].persist(chunk);

--- a/liblpe/LivePresetsExtension.cpp
+++ b/liblpe/LivePresetsExtension.cpp
@@ -412,6 +412,10 @@ bool LPE::recallState(ProjectStateContext* ctx, bool) {
 void LPE::saveState(ProjectStateContext* ctx, bool) {
     auto *proj = GetCurrentProjectInLoadSave();
 
+    // only save data when there are presets
+    if (mModels[proj].mPresets.empty())
+        return
+
     WDL_FastString chunk;
     mModels[proj].persist(chunk);
 


### PR DESCRIPTION
… is at least one preset.